### PR TITLE
bugfix: Add missing dot in base url when triggering the build - #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --base=./",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },


### PR DESCRIPTION
### Description

Looking into a [GitHub thread](https://github.com/vitejs/vite/discussions/9008#discussioncomment-3113359) a solution is proposed. Testing its effectiveness in this PR.

**Project**: [Issue link](https://github.com/juanpb96/FEM_space-tourism-website/issues/10)

### Changes

- Add `--base:./` in build script.