### PR TITLE
bugfix: Move Publish to Chromatic into build job

### DIFF
--- a/.github/workflows/build-deploy-gh-pages.yml
+++ b/.github/workflows/build-deploy-gh-pages.yml
@@ -45,6 +45,10 @@ jobs:
         uses: actions/upload-pages-artifact@v2
         with:
           path: './dist'
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   # Deployment job
   deploy:
@@ -57,7 +61,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-      - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
### Description
Build and deploy workflow is failing due to Chromatic step. Probably, moving the step into the build job could solve the issue.

**Project**: [Issue link](https://github.com/juanpb96/FEM_space-tourism-website/issues/19)

### Changes
- Move the Chromatic step into the build job
