### PR TITLE
feat(37): Create Heading component

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -9,7 +9,7 @@ interface HeadingProps {
 
 export const Heading = ({text, variant}: HeadingProps) => {
   return (
-    <h3 className={[styles['heading'], styles[`heading--${variant}`]].join(' ')}>
+    <h3 className={`${styles['heading']} ${styles[`heading--${variant}`]}`}>
       {text}
     </h3>
   );

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,0 +1,9 @@
+import styles from './styles/heading.module.scss';
+
+export const Heading = () => {
+  return (
+    <div className={styles['wrapper']}>
+      Heading
+    </div>
+  );
+};

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,9 +1,16 @@
 import styles from './styles/heading.module.scss';
 
-export const Heading = () => {
+type Variant = 'small' | 'medium' | 'large';
+
+interface HeadingProps {
+  text: string;
+  variant: Variant;
+}
+
+export const Heading = ({text, variant}: HeadingProps) => {
   return (
-    <div className={styles['wrapper']}>
-      Heading
-    </div>
+    <h3 className={[styles['heading'], styles[`heading--${variant}`]].join(' ')}>
+      {text}
+    </h3>
   );
 };

--- a/src/components/Heading/stories/Heading.stories.tsx
+++ b/src/components/Heading/stories/Heading.stories.tsx
@@ -5,6 +5,16 @@ import { Heading } from '../Heading';
 const meta: Meta<typeof Heading> = {
   title: 'Components/Heading',
   component: Heading,
+  argTypes: {
+    variant: {
+      options: ['small', 'medium', 'large'],
+      control: 'select'
+    }
+  },
+  args: {
+    text: 'Douglas Hurley',
+    variant: 'small'
+  }
 };
 
 export default meta;

--- a/src/components/Heading/stories/Heading.stories.tsx
+++ b/src/components/Heading/stories/Heading.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Heading } from '../Heading';
+
+const meta: Meta<typeof Heading> = {
+  title: 'Components/Heading',
+  component: Heading,
+};
+
+export default meta;
+type Story = StoryObj<typeof Heading>;
+
+export const Default: Story = {};

--- a/src/components/Heading/styles/heading.module.scss
+++ b/src/components/Heading/styles/heading.module.scss
@@ -1,0 +1,3 @@
+.wrapper {
+  display: block;
+}

--- a/src/components/Heading/styles/heading.module.scss
+++ b/src/components/Heading/styles/heading.module.scss
@@ -14,9 +14,43 @@
   }
 
   &--large {
+    $line-height: 100;
+    $font-size: 80;
+
     font-size: 5rem;
-    line-height: calc(100 / 80); // line-height in px / font-size in px
+    line-height: calc($line-height / $font-size);
   }
 }
 
-// TODO: Add styles for tablet and desktop
+@media screen and (min-width: v.$tablet) {
+  .heading {
+    &--small {
+      font-size: 2.5rem;
+    }
+  
+    &--medium {
+      font-size: 5rem;
+    }
+  
+    &--large {
+      $line-height: 150;
+      $font-size: 150;
+  
+      font-size: 9.375rem;
+      line-height: calc($line-height / $font-size);
+    }
+  }
+}
+
+@media screen and (min-width: v.$desktop) {
+  .heading {
+    &--small {
+      font-size: 3.5rem;
+    }
+  
+    &--medium {
+      font-size: 6.25rem;
+    }
+
+  }
+}

--- a/src/components/Heading/styles/heading.module.scss
+++ b/src/components/Heading/styles/heading.module.scss
@@ -1,3 +1,22 @@
-.wrapper {
-  display: block;
+@use 'src/styles/variables' as v;
+
+.heading {
+  color: v.$white;
+  text-transform: uppercase;
+  font-weight: 400;
+
+  &--small {
+    font-size: 1.5rem;
+  }
+
+  &--medium {
+    font-size: 3.5rem;
+  }
+
+  &--large {
+    font-size: 5rem;
+    line-height: calc(100 / 80); // line-height in px / font-size in px
+  }
 }
+
+// TODO: Add styles for tablet and desktop


### PR DESCRIPTION
### Description
Create `Heading` component with font-size variants. 

**Project**: [Issue link](https://github.com/juanpb96/FEM_space-tourism-website/issues/37)

### Changes
- Create `Heading` component files
- Add font-size variants `small`, `medium`, and `large`
- Create Storybook story with controls to toggle component `text` and `variants`
