### PR TITLE
fix(44): Fix NavigationBar

### DIFF
--- a/src/components/NavigationBar/Menu.tsx
+++ b/src/components/NavigationBar/Menu.tsx
@@ -3,8 +3,8 @@ import { NavLink } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import styles from './styles/menu.module.scss';
 import { useScreenType } from '../../hooks/useScreenType';
-import { menuVariants, optionsVariants } from './animations/menu.variants';
-import { getActiveClass, getMobileAnimation, getBarAnimation } from './utils/Menu.utils';
+import { menuVariants } from './animations/menu.variants';
+import { getActiveClass, getBarAnimation } from './utils/Menu.utils';
 
 /* TODO:
   - Include active state for mobile and tablet
@@ -16,7 +16,7 @@ const PAGES = ['Home', 'Destination', 'Crew', 'Technology'];
 
 const baseFontSize = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'));
 
-export const Menu = ({ isOpen = true }) => {
+export const Menu = () => {
   const [activeMenuOptionIndex, setActiveMenuOptionIndex] = useState(0);
   const [options, setOptions] = useState<HTMLLIElement[]>([]);
   const screenType = useScreenType();
@@ -52,12 +52,7 @@ export const Menu = ({ isOpen = true }) => {
   };
 
   return (
-    <motion.nav
-        initial={false}
-        animate={getMobileAnimation(isOpen, screenType)}
-        variants={optionsVariants}
-        className={styles['menu']}
-    >
+    <nav className={styles['menu']}>
       <ol ref={olRef}>
         {
           PAGES.map((page, index) => (
@@ -86,6 +81,6 @@ export const Menu = ({ isOpen = true }) => {
         animate={getBarAnimation(screenType)}
         variants={menuVariants}
       />
-    </motion.nav>
+    </nav>
   );
 };

--- a/src/components/NavigationBar/Menu.tsx
+++ b/src/components/NavigationBar/Menu.tsx
@@ -6,12 +6,6 @@ import { useScreenType } from '../../hooks/useScreenType';
 import { menuVariants } from './animations/menu.variants';
 import { getActiveClass, getBarAnimation } from './utils/Menu.utils';
 
-/* TODO:
-  - Include active state for mobile and tablet
-  - Check keyboard navigation
-  - Validate behavior on viewport resize 
-*/
-
 const PAGES = ['Home', 'Destination', 'Crew', 'Technology'];
 
 const baseFontSize = parseFloat(window.getComputedStyle(document.documentElement).getPropertyValue('font-size'));
@@ -25,30 +19,40 @@ export const Menu = () => {
 
   useEffect(() => {
     const olElement = olRef.current;
-    const barElement = barRef.current;
-    
-    if (screenType !== 'mobile' && olElement && barElement) {
+
+    if (olElement) {
       const liElements = Array.from(olElement.getElementsByTagName('li'));
       setOptions(liElements);
-      
-      const activeMenuOption = liElements[activeMenuOptionIndex];
-      barElement.style.width = `${activeMenuOption.offsetWidth / baseFontSize}rem`;      
     }
-  }, [activeMenuOptionIndex, screenType]);
+  }, [])
+
+  useEffect(() => {
+    const barElement = barRef.current;
+
+    const resizeObserver = new ResizeObserver((entries) => {      
+      if (barElement) {
+        const activeMenuOptionWidth = Math.round(entries[0].contentBoxSize[0].inlineSize);
+        barElement.style.width = `${activeMenuOptionWidth / baseFontSize}rem`; 
+      }
+    });
+    
+    const calculateBarWidth = () => {
+      if (options.length && barElement) {    
+        const activeMenuOption = options[activeMenuOptionIndex];            
+        resizeObserver.observe(activeMenuOption);
+      }
+    }
+
+    calculateBarWidth();
+
+    return () => {
+      resizeObserver.disconnect();
+    }
+  }, [activeMenuOptionIndex, options]);
 
   const onLinkClick = (e: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>, index: number) => {
     e.preventDefault();   
     setActiveMenuOptionIndex(index);
-
-    if (screenType === 'mobile') {
-      return;
-    }
-
-    const elementSize = (e.target as HTMLLinkElement).offsetWidth / baseFontSize 
-    
-    if (barRef.current) {
-      barRef.current.style.width = `${elementSize}rem`;
-    }
   };
 
   return (

--- a/src/components/NavigationBar/MenuButton.tsx
+++ b/src/components/NavigationBar/MenuButton.tsx
@@ -7,6 +7,7 @@ const Rect = (props: SVGMotionProps<SVGRectElement>) => {
     <motion.rect
       width="24"
       height="3"
+      viewBox="0 0 24 3"
       fill="#D0D6F9"
       {...props}
     />
@@ -39,12 +40,14 @@ export const MenuButton = ({isOpen, onToggle}: MenuButtonProps) => {
         animate={animateVariant}
         variants={svgVariants}
         role="presentation"
+        className={styles['svg']}
       >
         <Rect
           className="top"
           initial={false}
           animate={animateVariant}
           variants={topRectVariants}
+          style={{ originX: '12px', originY: '1.5px' }}
         />
         <Rect
           className="middle"
@@ -60,6 +63,7 @@ export const MenuButton = ({isOpen, onToggle}: MenuButtonProps) => {
           initial={false}
           animate={animateVariant}
           variants={bottomRectVariants}
+          style={{ originX: '12px', originY: '19.5px' }}
         />
       </motion.svg>               
     </button>

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -1,0 +1,60 @@
+import { MouseEvent, useRef, useState } from "react";
+import { NavLink } from "react-router-dom";
+import { getActiveClass, getBarAnimation, getMobileAnimation } from "./utils/Menu.utils";
+import { motion } from "framer-motion";
+import { menuVariants, optionsVariants } from "./animations/menu.variants";
+import styles from './styles/menu.module.scss';
+
+const PAGES = ['Home', 'Destination', 'Crew', 'Technology'];
+
+interface MenuMobileProps {
+  isOpen: boolean;
+}
+
+export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
+  const [activeMenuOptionIndex, setActiveMenuOptionIndex] = useState(0);
+  const olRef = useRef<HTMLOListElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);  
+
+  const onLinkClick = (e: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>, index: number) => {
+    e.preventDefault();
+    setActiveMenuOptionIndex(index);
+  };
+
+  return (
+    <motion.nav
+        initial={false}
+        animate={getMobileAnimation(isOpen)}
+        variants={optionsVariants}
+        className={styles['menu']}
+    >
+      <ol ref={olRef}>
+        {
+          PAGES.map((page, index) => (
+            <li key={page}>
+              <NavLink
+                to={`/${page}`}
+                className={getActiveClass}
+                onClick={(e) => onLinkClick(e, index)}
+              >
+                <span className={styles['counter']}>0{index}</span>
+                {page}
+              </NavLink>
+            </li>
+          ))
+        }
+      </ol>
+      <motion.div
+        ref={barRef}
+        className={styles['bar']}
+        initial={false}
+        custom={{
+          screenType: 'mobile',
+          index: activeMenuOptionIndex
+        }}
+        animate={getBarAnimation('mobile')}
+        variants={menuVariants}
+      />
+    </motion.nav>
+  );
+};

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -11,6 +11,11 @@ interface MenuMobileProps {
   isOpen: boolean;
 }
 
+/**
+ * TODO: Increase menu options clickable area to enhance usability - Issue #48
+ * - Update hover query by including pointer fine
+ */
+ 
 export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
   const [activeMenuOptionIndex, setActiveMenuOptionIndex] = useState(0);
   const olRef = useRef<HTMLOListElement>(null);

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,19 +1,18 @@
 import { useEffect, useState } from 'react';
 import { MenuButton } from './MenuButton';
 import { Menu } from './Menu';
-import styles from './styles/navigation-bar.module.scss';
 import { useScreenType } from '../../hooks/useScreenType';
+import { MenuMobile } from './MenuMobile';
+import styles from './styles/navigation-bar.module.scss';
 
 export const NavigationBar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const screenType = useScreenType();
   
-  // TODO: Check behavior when resizing the screen
   useEffect(() => {
-    if (screenType !== 'mobile') {
-      setIsOpen(true);
-    }
+    setIsOpen(false)
   }, [screenType])
+  
 
   const onToggle = () => {
     setIsOpen(!isOpen);
@@ -21,8 +20,13 @@ export const NavigationBar = () => {
 
   return (
     <div className={styles['nav-container']}>
+      {
+        screenType === 'mobile'
+        ? <MenuMobile isOpen={isOpen} />
+        : <Menu />
+      }
+      {/* TODO: Increase button clickable area to enhance usability */}
       <MenuButton isOpen={isOpen} onToggle={onToggle} />
-      <Menu isOpen={isOpen} />
     </div>
   );
 };

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -25,7 +25,7 @@ export const NavigationBar = () => {
         ? <MenuMobile isOpen={isOpen} />
         : <Menu />
       }
-      {/* TODO: Increase button clickable area to enhance usability */}
+      {/* TODO: Increase button clickable area to enhance usability - Issue #48 */}
       <MenuButton isOpen={isOpen} onToggle={onToggle} />
     </div>
   );

--- a/src/components/NavigationBar/animations/menu.variants.ts
+++ b/src/components/NavigationBar/animations/menu.variants.ts
@@ -18,7 +18,7 @@ const sumOptionsWidth = ({options, index}: WithOptionsProps) => {
 };
 
 // TODO: Create constant values for numbers without a clear explanation
-const calculateHorizontalMoveByViewport = ({options, index, screenType}: MenuHorizontalVariantProps) => {
+const calculateHorizontalMoveByViewport = ({screenType, options, index}: MenuHorizontalVariantProps) => {
   const optionsGap = screenType === 'tablet' ? 38 : 48;
   return sumOptionsWidth({options, index}) + index * optionsGap;
 };

--- a/src/components/NavigationBar/stories/NavigationBar.stories.tsx
+++ b/src/components/NavigationBar/stories/NavigationBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 
 import { NavigationBar } from '../NavigationBar';
 import { defaultViewport, chromaticViewport } from '../../constants/stories-viewports';
@@ -11,6 +11,9 @@ const meta = {
   component: NavigationBar,
   tags: ['autodocs'],
   decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen'
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const anchorElement = canvas.getByRole('link', { name: /technology/i });
@@ -23,7 +26,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// TODO: Add background image to test blur effect
 export const NavigationBarOnMobile: Story = {
   parameters: {
     viewport: {
@@ -33,6 +35,13 @@ export const NavigationBarOnMobile: Story = {
       viewports: [chromaticViewport.mobile]
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole('button', { name: /menu/i });
@@ -45,6 +54,12 @@ export const NavigationBarOnMobile: Story = {
   }
 };
 
+const withWrapper: Decorator = (Story) => (
+  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+    <Story />
+  </div>
+);
+
 export const NavigationBarOnTablet: Story = {
   parameters: {
     viewport: {
@@ -54,6 +69,9 @@ export const NavigationBarOnTablet: Story = {
       viewports: [chromaticViewport.tablet]
     }
   },
+  decorators: [withWrapper],
 };
 
-export const NavigationBarDesktop: Story = {}
+export const NavigationBarDesktop: Story = {
+  decorators: [withWrapper],
+}

--- a/src/components/NavigationBar/styles/menu-button.module.scss
+++ b/src/components/NavigationBar/styles/menu-button.module.scss
@@ -4,3 +4,7 @@
   border: none;
   padding: 0;
 }
+
+.svg {
+  height: 24px;
+}

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -59,6 +59,7 @@
   inset: 0 0 0 auto;
   background-color: rgba(255, 255, 255, 0.04);
   backdrop-filter: blur(40.77px);
+  z-index: 1;
 
   & ol {
     display: flex;

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -55,6 +55,7 @@
 .menu {
   width: 15.875rem;
   height: 100vh;
+  height: 100dvh;
   position: fixed;
   inset: 0 0 0 auto;
   background-color: rgba(255, 255, 255, 0.04);
@@ -103,6 +104,7 @@
   top: -0.375rem;
 }
 
+// TODO: Move mobile styles to a file dedicated to `MenuMobile` and adjust the other styles here
 @media screen and (min-width: v.$tablet) {
   .menu {
     display: flex;
@@ -111,8 +113,6 @@
     width: auto;
     height: 6rem;
     position: revert;
-    // TODO: Check backdrop behavior
-    // backdrop-filter: unset;
 
     & ol {
       flex-direction: row;

--- a/src/components/NavigationBar/styles/navigation-bar.module.scss
+++ b/src/components/NavigationBar/styles/navigation-bar.module.scss
@@ -14,6 +14,10 @@
 }
 
 @media screen and (min-width: v.$tablet) {
+  .nav-container {
+    width: fit-content;
+  }
+
   .nav-container button {
     display: none;
   }

--- a/src/components/NavigationBar/utils/Menu.utils.ts
+++ b/src/components/NavigationBar/utils/Menu.utils.ts
@@ -5,12 +5,8 @@ const getActiveClass = ({isActive}: {isActive: boolean}) => {
   return isActive ? styles['active'] : '';
 };
 
-const getMobileAnimation = (isOpen: boolean, screenType: ScreenType) => {
-  if (screenType === 'mobile') {
-    return isOpen ? "open" : "closed"
-  }
-
-  return "";
+const getMobileAnimation = (isOpen: boolean) => {
+  return isOpen ? "open" : "closed";
 };
 
 const getBarAnimation = (screenType: ScreenType) => {


### PR DESCRIPTION
### Description
Adjust `NavigationBar`, `Menu` structure and styles, and create `MenuMobile`.

**Project**: [Issue link](https://github.com/juanpb96/FEM_space-tourism-website/issues/44)

### Changes
- Create `MenuMobile` to handle animation complexity for mobile and bigger screens separated
- Close the mobile menu when `screenType` changes
- Fix `X` button animation
- Add `ResizeObserver` to keep track of changes on `activeMenuOption` width and resize the "location" bar accordingly
- Put `Menu` on top of other elements
- Include usability TODOs
- Adjust `NavigationBar` stories

### Evidences

*Before:*

![Menu opened on mobile with overlapping elements, bad transition from open image to close image, and location bar being wider than it should](https://github.com/juanpb96/FEM_space-tourism-website/assets/76854902/aa629a77-ac8b-4ce0-ab7f-202f9a783d50)

![Menu on desktop with location bar being wider than active menu option](https://github.com/juanpb96/FEM_space-tourism-website/assets/76854902/0360d68f-b0ce-4ff6-831d-03280452bbaa)

*After:*

![Menu opened on mobile with all the fixed details](https://github.com/juanpb96/FEM_space-tourism-website/assets/76854902/1ea0e0ff-40f8-4266-98fa-c175c5a5baa5)

![Menu on desktop with location bar being equally wider to active menu option](https://github.com/juanpb96/FEM_space-tourism-website/assets/76854902/1a963278-76d5-4ea7-b188-ef545b2249e7)



