### PR TITLE
fix(47): Set build assets directory path to the root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ 
   plugins: [react()],
-})
+  build: { assetsDir: '' }
+}));


### PR DESCRIPTION
### Description
By default, when Vite builds the project, it will generate the CSS file inside the `./assets` path, causing prod images to look for the background images in `./assets/assets`. It was necessary to set `build.assetsDir` to an empty string to generate the CSS file in the root folder so the images can be found in `./assets` both in local env and prod.

**Project**: [Issue link](https://github.com/juanpb96/FEM_space-tourism-website/issues/47)

### Changes
- Include `build.assetsDir` in `vite.config.ts`
- Remove [default value](https://vitejs.dev/config/build-options.html#build-assetsdir)

### Evidence

![Project build](https://github.com/juanpb96/FEM_space-tourism-website/assets/76854902/2e855da4-8f1f-441b-bda4-8db8b024a081)
