### PR TITLE
chore(NO-TICKET): Update build-deploy-gh-pages.yml actions version

### DIFF
--- a/.github/workflows/build-deploy-gh-pages.yml
+++ b/.github/workflows/build-deploy-gh-pages.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'npm'
@@ -40,9 +40,9 @@ jobs:
       - name: Build
         run: npm run build
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './dist'
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Description
Update version in actions as the current version being used is deprecated and affecting the build job.

### Changes
- Upgrade checkout action from v3 to v4
- Upgrade setup-node action from v3 to v4
- Upgrade configure-pages action from v3 to v5
- Upgrade upload-pages-artifact action from v2 to v4
- Upgrade deploy-pages action from v2 to v4
