### PR TITLE
fix(NO-TICKET): Adjust actions/upload-pages-artifact version

### DIFF
--- a/.github/workflows/build-deploy-gh-pages.yml
+++ b/.github/workflows/build-deploy-gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist'
 


### PR DESCRIPTION
### Description
Fix the version for actions/upload-pages-artifact as the latest available version is v3.0.1. See https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1

### Changes
- Change actions/upload-pages-artifact version from v4 to v3
