### PR TITLE
feat(64): Add 404.html to prevent GitHub from showing its default 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>404 Not Found - Redirecting...</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+      window.location = "/";
+    </script>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { AppRouter } from './routes/AppRouter';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { AppRouter } from "./routes/AppRouter";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <AppRouter />
-  </React.StrictMode>,
-)
+  </React.StrictMode>
+);

--- a/src/pages/Home/styles/home.module.scss
+++ b/src/pages/Home/styles/home.module.scss
@@ -1,7 +1,7 @@
-@use 'src/styles/variables' as v;
-@use 'src/styles/mixins/page-background' as m;
+@use "src/styles/variables" as v;
+@use "src/styles/mixins/page-background" as m;
 
-$page-name: 'home';
+$page-name: "home";
 
 .wrapper {
   display: flex;
@@ -47,6 +47,7 @@ $page-name: 'home';
     align-items: flex-start;
   }
 
+  // FIXME: This is set as a conditional style, when passed down to the ExploreButton component it could result as an undefined value
   .explore {
     align-self: flex-end;
   }


### PR DESCRIPTION
### Description
This pull request is intended to help with client-side routing by adding a custom 404.html file which redirects to the index.html generated after the build process. 

**Project**: [Issue #64](https://github.com/juanpb96/FEM_space-tourism-website/issues/64)

### Changes
- Add 404.html in the public folder.
  - This file redirects to index.html to prevent GitHub from displaying its default 404 page and handle all routing processes from the client's side.

### Note
It is important to note that this pull request needs to be merged and tested to validate if the expected behavior is present. Otherwise, this change needs to be reversed.
