### PR TITLE
Refactor/59 update project UI breakpoints

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,30 +1,25 @@
-import { useEffect, useState } from 'react';
-import { MenuButton } from './MenuButton';
-import { Menu } from './Menu';
-import { useScreenType } from '../../hooks/useScreenType';
-import { MenuMobile } from './MenuMobile';
-import styles from './styles/navigation-bar.module.scss';
+import { useEffect, useState } from "react";
+import { MenuButton } from "./MenuButton";
+import { Menu } from "./Menu";
+import { useScreenType } from "../../hooks/useScreenType";
+import { MenuMobile } from "./MenuMobile";
+import styles from "./styles/navigation-bar.module.scss";
 
 export const NavigationBar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const screenType = useScreenType();
-  
+
   useEffect(() => {
-    setIsOpen(false)
-  }, [screenType])
-  
+    setIsOpen(false);
+  }, [screenType]);
 
   const onToggle = () => {
     setIsOpen(!isOpen);
   };
 
   return (
-    <div className={styles['nav-container']}>
-      {
-        screenType === 'mobile'
-        ? <MenuMobile isOpen={isOpen} />
-        : <Menu />
-      }
+    <div className={styles["nav-container"]}>
+      {screenType === "mobile" ? <MenuMobile isOpen={isOpen} /> : <Menu />}
       {/* TODO: Increase button clickable area to enhance usability - Issue #48 */}
       <MenuButton isOpen={isOpen} onToggle={onToggle} />
     </div>

--- a/src/components/Subtitle/styles/subtitle.module.scss
+++ b/src/components/Subtitle/styles/subtitle.module.scss
@@ -1,6 +1,6 @@
-@use 'src/styles/variables' as v;
-@use 'src/styles/fonts' as fonts;
-@use 'src/styles/mixins/responsive-font' as m;
+@use "src/styles/variables" as v;
+@use "src/styles/fonts" as fonts;
+@use "src/styles/mixins/responsive-font" as m;
 
 .subtitle {
   @include fonts.barlow-condensed;
@@ -41,5 +41,11 @@
     $font-size: 28;
     $line-height: 34;
     @include m.responsive-font($font-size, $line-height);
+
+    &--with-prefix {
+      span {
+        margin-right: 28px;
+      }
+    }
   }
 }

--- a/src/hooks/useScreenType.ts
+++ b/src/hooks/useScreenType.ts
@@ -1,37 +1,40 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
 const BREAKPOINTS = {
-  tablet: '(min-width: 48rem) and (max-width: 63.9375rem)',
-  desktop: '(min-width: 64rem) and (max-width: 89.9375rem)',
-  'large-desktop': '(min-width: 90rem)',
+  tablet: "(min-width: 37.5rem) and (max-width: 81.1875rem)",
+  desktop: "(min-width: 81.25rem) and (max-width: 89.9375rem)",
+  "large-desktop": "(min-width: 90rem)",
 };
 
-export type ScreenType = keyof typeof BREAKPOINTS | 'mobile';
+export type ScreenType = keyof typeof BREAKPOINTS | "mobile";
 
 const getWindowType = () => {
-  for (const breakpoint in BREAKPOINTS) {     
-    if (window.matchMedia(BREAKPOINTS[breakpoint as keyof typeof BREAKPOINTS]).matches) {
+  for (const breakpoint in BREAKPOINTS) {
+    if (
+      window.matchMedia(BREAKPOINTS[breakpoint as keyof typeof BREAKPOINTS])
+        .matches
+    ) {
       return breakpoint as keyof typeof BREAKPOINTS;
     }
   }
 
-  return 'mobile';
+  return "mobile";
 };
 
 export const useScreenType = () => {
-  const [screenType, setScreenType] = useState<ScreenType>(getWindowType); 
+  const [screenType, setScreenType] = useState<ScreenType>(getWindowType);
 
   useEffect(() => {
     const onResize = () => {
       setScreenType(getWindowType());
     };
 
-    window.addEventListener('resize', onResize);
-  
+    window.addEventListener("resize", onResize);
+
     return () => {
-      window.removeEventListener('resize', onResize);
-    }
-  }, []);  
+      window.removeEventListener("resize", onResize);
+    };
+  }, []);
 
   return screenType;
-}
+};

--- a/src/hooks/useScreenType.ts
+++ b/src/hooks/useScreenType.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 const BREAKPOINTS = {
   tablet: "(min-width: 37.5rem) and (max-width: 81.1875rem)",
-  desktop: "(min-width: 81.25rem) and (max-width: 89.9375rem)",
+  desktop: "(min-width: 81.25rem)",
 };
 
 export type ScreenType = keyof typeof BREAKPOINTS | "mobile";

--- a/src/hooks/useScreenType.ts
+++ b/src/hooks/useScreenType.ts
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 const BREAKPOINTS = {
   tablet: "(min-width: 37.5rem) and (max-width: 81.1875rem)",
   desktop: "(min-width: 81.25rem) and (max-width: 89.9375rem)",
-  "large-desktop": "(min-width: 90rem)",
 };
 
 export type ScreenType = keyof typeof BREAKPOINTS | "mobile";

--- a/src/pages/Crew/Crew.tsx
+++ b/src/pages/Crew/Crew.tsx
@@ -20,6 +20,7 @@ export const Crew = () => {
     return <></>;
   }
 
+  // TODO: Test keyboard navigation with Screen Reader
   return (
     <main className={styles["wrapper"]}>
       <Subtitle prefix="02" title="Meet your crew" />

--- a/src/pages/Crew/styles/crew.module.scss
+++ b/src/pages/Crew/styles/crew.module.scss
@@ -152,4 +152,8 @@ $page-name: "crew";
   @media screen and (min-width: v.$tablet) {
     height: 6px;
   }
+
+  @media screen and (min-width: v.$desktop) {
+    height: 28px;
+  }
 }

--- a/src/pages/Crew/styles/crew.module.scss
+++ b/src/pages/Crew/styles/crew.module.scss
@@ -23,7 +23,7 @@ $page-name: "crew";
     margin-inline: auto;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     width: min(1110px, 80%);
     text-align: left;
   }
@@ -36,7 +36,7 @@ $page-name: "crew";
     margin-left: -58px;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     flex-basis: 100%;
     margin: 0;
   }
@@ -58,7 +58,7 @@ $page-name: "crew";
       "photo";
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     grid-template-areas:
       "details"
       "pagination";
@@ -84,7 +84,7 @@ $page-name: "crew";
 .photo-wrapper {
   grid-area: photo;
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     position: absolute;
     bottom: 0;
     right: 0;
@@ -101,7 +101,7 @@ $page-name: "crew";
     margin-top: 40px;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     height: initial;
   }
 }
@@ -134,7 +134,7 @@ $page-name: "crew";
     margin-block: 60px 0;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     opacity: 0.5042;
     font-size: 2rem;
     margin-top: 154px;
@@ -142,7 +142,7 @@ $page-name: "crew";
 }
 
 .description-wrapper {
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     width: 27.75rem;
     margin-bottom: 120px;
   }

--- a/src/pages/Crew/styles/crew.module.scss
+++ b/src/pages/Crew/styles/crew.module.scss
@@ -64,12 +64,11 @@ $page-name: "crew";
 
   @media screen and (min-width: v.$desktop) {
     grid-template-areas:
-      "details"
-      "pagination";
-    grid-template-rows: 545px 1fr;
-    position: relative;
+      "details photo"
+      "pagination photo";
+    grid-template-rows: 545px 109px;
+    gap: 0;
     place-items: revert;
-    height: calc(100dvh - 130px - 80px);
   }
 }
 
@@ -87,9 +86,8 @@ $page-name: "crew";
   object-fit: contain;
 
   @media screen and (min-width: v.$desktop) {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    align-self: self-end;
+    height: revert;
   }
 }
 

--- a/src/pages/Crew/styles/crew.module.scss
+++ b/src/pages/Crew/styles/crew.module.scss
@@ -18,13 +18,12 @@ $page-name: "crew";
   @media screen and (min-width: v.$tablet) {
     padding: 0;
     padding-top: 40px;
-    // TODO: Check once validating page view with the navigation bar
-    width: calc(573 / 16 * 1rem);
     margin-inline: auto;
   }
 
   @media screen and (min-width: v.$desktop) {
-    width: min(1110px, 80%);
+    max-width: 1110px;
+    padding-top: 76px;
     text-align: left;
   }
 }
@@ -33,7 +32,7 @@ $page-name: "crew";
 .wrapper h2 {
   @media screen and (min-width: v.$tablet) {
     text-align: left;
-    margin-left: -58px;
+    margin-left: 40px;
   }
 
   @media screen and (min-width: v.$desktop) {
@@ -50,12 +49,17 @@ $page-name: "crew";
     "divider"
     "pagination"
     "details";
+  grid-template-rows: 222px auto auto auto;
+  margin-top: 32px;
 
   @media screen and (min-width: v.$tablet) {
     grid-template-areas:
       "details"
       "pagination"
       "photo";
+    row-gap: 40px;
+    grid-template-rows: auto auto minmax(222px, 528px);
+    margin-top: revert;
   }
 
   @media screen and (min-width: v.$desktop) {
@@ -75,14 +79,12 @@ $page-name: "crew";
 
 .details {
   grid-area: details;
-
-  @media screen and (min-width: v.$tablet) {
-    margin-bottom: 40px;
-  }
 }
 
 .photo-wrapper {
   grid-area: photo;
+  height: 100%;
+  object-fit: contain;
 
   @media screen and (min-width: v.$desktop) {
     position: absolute;
@@ -92,14 +94,7 @@ $page-name: "crew";
 }
 
 .photo {
-  height: 222px;
-  margin-top: 32px;
-
-  // TODO: Need to check how it looks when the screen displays the navbar
-  @media screen and (min-width: v.$tablet) {
-    height: 532px;
-    margin-top: 40px;
-  }
+  max-height: 100%;
 
   @media screen and (min-width: v.$desktop) {
     height: initial;
@@ -142,9 +137,14 @@ $page-name: "crew";
 }
 
 .description-wrapper {
+  @media screen and (min-width: v.$tablet) {
+    width: 37rem;
+    text-wrap: balance;
+  }
+
   @media screen and (min-width: v.$desktop) {
     width: 27.75rem;
-    margin-bottom: 120px;
+    text-wrap: revert;
   }
 }
 

--- a/src/pages/Destination/Destination.tsx
+++ b/src/pages/Destination/Destination.tsx
@@ -31,10 +31,12 @@ export const Destination = () => {
         <InnerNavigationBar pages={pages} setActivePage={onPaginationClick} />
         <div className={styles["spacer"]} />
         <Heading text={name} variant="medium" />
-        <Description>{description}</Description>
-        <div className={styles["details"]}>
-          <DestinationDetails title="Avg. Distance" value={distance} />
-          <DestinationDetails title="Est. Travel Time" value={travel} />
+        <div className={styles["description-wrapper"]}>
+          <Description>{description}</Description>
+          <div className={styles["details"]}>
+            <DestinationDetails title="Avg. Distance" value={distance} />
+            <DestinationDetails title="Est. Travel Time" value={travel} />
+          </div>
         </div>
       </div>
     </main>

--- a/src/pages/Destination/styles/destination.module.scss
+++ b/src/pages/Destination/styles/destination.module.scss
@@ -1,7 +1,7 @@
-@use 'src/styles/variables' as v;
-@use 'src/styles/mixins/page-background' as m;
+@use "src/styles/variables" as v;
+@use "src/styles/mixins/page-background" as m;
 
-$page-name: 'destination';
+$page-name: "destination";
 
 .wrapper {
   display: flex;
@@ -18,7 +18,7 @@ $page-name: 'destination';
     margin-inline: auto;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     width: min(80%, 1110px);
     padding-block: 76px;
     flex-direction: row;
@@ -34,7 +34,7 @@ $page-name: 'destination';
     margin-left: -58px;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     flex-basis: 100%;
     margin: 0;
   }
@@ -50,7 +50,7 @@ $page-name: 'destination';
     margin-block: 60px 54px;
   }
 
-  @media screen and (min-width: v.$large-desktop) {
+  @media screen and (min-width: v.$desktop) {
     width: 445px;
     margin-block: 98px 0;
     margin-left: 64px;

--- a/src/pages/Destination/styles/destination.module.scss
+++ b/src/pages/Destination/styles/destination.module.scss
@@ -13,13 +13,11 @@ $page-name: "destination";
 
   @media screen and (min-width: v.$tablet) {
     padding: 40px 0;
-    // TODO: Check once validating page view with the navigation bar
-    width: calc(573 / 16 * 1rem);
     margin-inline: auto;
   }
 
   @media screen and (min-width: v.$desktop) {
-    width: min(80%, 1110px);
+    max-width: 1110px;
     padding-block: 76px;
     flex-direction: row;
     flex-wrap: wrap;
@@ -31,7 +29,7 @@ $page-name: "destination";
 .wrapper h2 {
   @media screen and (min-width: v.$tablet) {
     align-self: flex-start;
-    margin-left: -58px;
+    margin-left: 40px;
   }
 
   @media screen and (min-width: v.$desktop) {
@@ -79,6 +77,16 @@ $page-name: "destination";
 .wrapper h3 {
   @media screen and (min-width: v.$tablet) {
     margin-bottom: 8px;
+  }
+}
+
+.description-wrapper {
+  @media screen and (min-width: v.$tablet) {
+    width: calc(573 / 16 * 1rem);
+  }
+
+  @media screen and (min-width: v.$desktop) {
+    width: min(80%, 1110px);
   }
 }
 

--- a/src/pages/Destination/styles/destination.module.scss
+++ b/src/pages/Destination/styles/destination.module.scss
@@ -86,27 +86,38 @@ $page-name: "destination";
   }
 
   @media screen and (min-width: v.$desktop) {
-    width: min(80%, 1110px);
+    width: fit-content;
   }
 }
 
 .details {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 32px;
-  width: 100%;
+  display: grid;
+  grid-template-areas:
+    "distance"
+    "travel-time";
+  row-gap: 32px;
+  justify-items: center;
   margin-top: 32px;
   padding-top: 32px;
   border-top: 1px solid v.$ship-grey;
 
+  & :first-child {
+    grid-area: distance;
+  }
+
+  & :last-child {
+    grid-area: travel-time;
+  }
+
   @media screen and (min-width: v.$tablet) {
-    flex-direction: row;
-    justify-content: space-evenly;
+    grid-template-areas: "distance travel-time";
+    grid-template-columns: 1fr 1fr;
+    margin-top: 50px;
+    padding-top: 28px;
   }
 
   @media screen and (min-width: v.$desktop) {
-    justify-content: flex-start;
-    gap: 80px;
+    justify-items: start;
+    margin-top: 54px;
   }
 }

--- a/src/pages/Technology/Technology.tsx
+++ b/src/pages/Technology/Technology.tsx
@@ -25,7 +25,7 @@ export const Technology = () => {
         {/* TODO: Add avif fallback for portrait images */}
         <picture>
           <source
-            media="(min-width: 64rem)"
+            media="(min-width: 81.25rem)"
             srcSet={currentTechnology.images.portrait}
           />
           {/* <source

--- a/src/pages/Technology/styles/technology.module.scss
+++ b/src/pages/Technology/styles/technology.module.scss
@@ -1,9 +1,9 @@
-@use 'src/styles/variables' as v;
-@use 'src/styles/fonts' as fonts;
-@use 'src/styles/mixins/page-background' as bg;
-@use 'src/styles/mixins/responsive-font' as m;
+@use "src/styles/variables" as v;
+@use "src/styles/fonts" as fonts;
+@use "src/styles/mixins/page-background" as bg;
+@use "src/styles/mixins/responsive-font" as m;
 
-$page-name: 'technology';
+$page-name: "technology";
 
 .wrapper {
   padding: 24px;
@@ -16,7 +16,8 @@ $page-name: 'technology';
   }
 
   @media screen and (min-width: v.$tablet) {
-    padding-top: 40px;
+    padding-inline: 0;
+    padding-block: 40px;
 
     & h2 {
       text-align: left;
@@ -34,6 +35,18 @@ $page-name: 'technology';
   // TODO: Adjust once breakpoints get updated - Issue #59
   @media screen and (min-width: 100rem) {
     margin-inline: auto;
+  }
+}
+
+.wrapper h2 {
+  @media screen and (min-width: v.$tablet) {
+    text-align: left;
+    margin-left: 40px;
+  }
+
+  @media screen and (min-width: v.$desktop) {
+    flex-basis: 100%;
+    margin: 0;
   }
 }
 
@@ -59,6 +72,8 @@ $page-name: 'technology';
 
   @media screen and (min-width: v.$tablet) {
     margin-block: 60px 56px;
+    margin-inline: 0;
+    width: 100%;
     min-height: 310px;
   }
 
@@ -85,7 +100,6 @@ article {
     margin-bottom: 44px;
   }
 }
-
 
 // TODO: Move terminology styles into a separated component and reuse it in destination details - Issue #50
 .terminology {

--- a/src/pages/Technology/styles/technology.module.scss
+++ b/src/pages/Technology/styles/technology.module.scss
@@ -55,7 +55,6 @@ $page-name: "technology";
     display: flex;
     flex-direction: row-reverse;
     justify-content: space-between;
-    align-items: center;
     gap: 130px;
     margin-top: 26px;
   }
@@ -88,6 +87,9 @@ article {
   @media screen and (min-width: v.$desktop) {
     display: flex;
     gap: 80px;
+    margin-top: calc(
+      137px - 26px
+    ); // 137px total space minus 26px from the top margin of the content
   }
 }
 

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -1,11 +1,13 @@
-@import url('https://fonts.googleapis.com/css2?family=Barlow&family=Barlow+Condensed&family=Bellefair&display=swap');
+// TODO: Add missing font weights
+@import url("https://fonts.googleapis.com/css2?family=Barlow&family=Barlow+Condensed&family=Bellefair&display=swap");
 
 @mixin bellefair {
   font-family: "Bellefair", Georgia, "Times New Roman", Baskerville, serif;
 }
 
 @mixin barlow-condensed {
-  font-family: "Barlow Condensed", "Arial Narrow", "Helvetica Neue", "Roboto Condensed", "Lato", "Open Sans Condensed", sans-serif;
+  font-family: "Barlow Condensed", "Arial Narrow", "Helvetica Neue",
+    "Roboto Condensed", "Lato", "Open Sans Condensed", sans-serif;
 }
 
 @mixin barlow {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,9 +1,9 @@
 /* Colors */
-$charcoal: #0B0D17;
-$lilac: #D0D6F9;
-$white: #FFFFFF;
+$charcoal: #0b0d17;
+$lilac: #d0d6f9;
+$white: #ffffff;
 $grey: #979797;
-$ship-grey: #383B4B;
+$ship-grey: #383b4b;
 
 // Opacity
 $opacity-1: 50%;
@@ -33,6 +33,6 @@ $ls-nav-text: 0.1688rem;
 // TODO: Body text depends on viewport size
 
 /* Viewport */
-$tablet: 48rem;
-$desktop: 64rem;
-$large-desktop: 90rem;
+$tablet: 600px;
+$desktop: 1300px;
+// $large-desktop: 1440px;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -35,4 +35,3 @@ $ls-nav-text: 0.1688rem;
 /* Viewport */
 $tablet: 600px;
 $desktop: 1300px;
-// $large-desktop: 1440px;


### PR DESCRIPTION
### Description
This pull request is aimed at enhancing the current breakpoints for all the pages with more accurate values for a better look and feel. This is done based on the device sizes provided by [statcounter](https://gs.statcounter.com/screen-resolution-stats/mobile/worldwide).

**Project**: [Issue #59](https://github.com/juanpb96/FEM_space-tourism-website/issues/59)

### Changes
- Update project breakpoint values in style files and in the useScreenType hook
- Large desktop breakpoint is removed as it is no longer needed
- Update mobile, tablet, and desktop styles in Destination, Crew, and Technology pages
- Enhance photo positioning and media query display

### Evidence

#### Destination
*Before*
![Destination Page breakpoint at 1024](https://github.com/user-attachments/assets/36850f1c-5075-4e55-86c6-04875ace6b5c)

*After*
![Enhaced Destination Page breakpoint at 1024](https://github.com/user-attachments/assets/40a25424-329f-44ec-90e5-c8d4ca5ea832)

#### Crew
*Before*
![Crew Page breakpoint at 1024](https://github.com/user-attachments/assets/a795e483-9f42-40c9-a7da-f93ef1f8369a)

*After*
![Enhaced Crew Page breakpoint at 1024](https://github.com/user-attachments/assets/1045ab80-0808-4177-b664-19cdb5f72874)

#### Technology
*Before*
![Technology Page breakpoint at 1024](https://github.com/user-attachments/assets/38fb81bc-68f5-4620-b020-2c09d57337ed)

*After*
![Enhaced Technology Page breakpoint at 1024](https://github.com/user-attachments/assets/d00b0a82-fc5b-40e7-bd20-44bb9dcf5104)
