### PR TITLE
refactor(60): Add header-content wrapper

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,13 +1,15 @@
-import styles from './styles/header.module.scss';
-import { Logo } from '../Logo/Logo';
-import { NavigationBar } from '../NavigationBar/NavigationBar';
+import styles from "./styles/header.module.scss";
+import { Logo } from "../Logo/Logo";
+import { NavigationBar } from "../NavigationBar/NavigationBar";
 
 export const Header = () => {
   return (
-    <header className={styles['header']}>
-      <Logo />
-      <div className={styles['line']} />
-      <NavigationBar />
+    <header className={styles["header"]}>
+      <div className={styles["header-content"]}>
+        <Logo />
+        <div className={styles["line"]} />
+        <NavigationBar />
+      </div>
     </header>
   );
 };

--- a/src/components/Header/styles/header.module.scss
+++ b/src/components/Header/styles/header.module.scss
@@ -1,11 +1,14 @@
-@use 'src/styles/variables' as v;
+@use "src/styles/variables" as v;
 
 .header {
+  padding-top: 24px;
+  padding-inline: 24px;
+}
+
+.header-content {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 24px;
-  padding-inline: 24px;
 }
 
 .line {
@@ -29,12 +32,17 @@
 
 @media screen and (min-width: v.$desktop) {
   .header {
+    display: grid;
+    grid-template-columns: auto min(100%, 1440px) auto;
     padding-top: 40px;
     padding-left: 55px;
+  }
+
+  .header-content {
+    grid-column-start: 2;
   }
 
   .line {
     display: initial;
   }
 }
-


### PR DESCRIPTION
### Description
This pull request includes a new `header-content` wrapper in the `Header` component. This new wrapper will be helpful to limit the header content width and place the content in the center of the screen in large viewports.

**Project**: [Issue #60](https://github.com/juanpb96/FEM_space-tourism-website/issues/60)

### Changes
- Include `header-content` wrapper
- Change `display` from `flex` to `grid` on desktop size in the `Header` component
- Add 3 columns, side ones are needed to center the content and the middle one is to limit heder content width

### Evidence
#### Before
![Header before](https://github.com/user-attachments/assets/45d60462-0fd0-4512-a3b2-072313a98775)

#### After
![Header after](https://github.com/user-attachments/assets/ac30f52a-415a-44a3-a6a1-c1f541b48270)
