### PR TITLE
refactor(108): Update MenuMobile

### DIFF
--- a/src/components/NavigationBar/MenuButton.tsx
+++ b/src/components/NavigationBar/MenuButton.tsx
@@ -1,6 +1,12 @@
-import { SVGMotionProps, motion, useReducedMotion } from 'framer-motion';
-import { bottomRectVariants, middleRectVariants, svgVariants, topRectVariants } from './animations/menu-button-variants';
-import styles from './styles/menu-button.module.scss';
+import React from "react";
+import { SVGMotionProps, motion, useReducedMotion } from "framer-motion";
+import {
+  bottomRectVariants,
+  middleRectVariants,
+  svgVariants,
+  topRectVariants,
+} from "./animations/menu-button-variants";
+import styles from "./styles/menu-button.module.scss";
 
 const Rect = (props: SVGMotionProps<SVGRectElement>) => {
   return (
@@ -11,7 +17,7 @@ const Rect = (props: SVGMotionProps<SVGRectElement>) => {
       fill="#D0D6F9"
       {...props}
     />
-  )
+  );
 };
 
 interface MenuButtonProps {
@@ -19,53 +25,57 @@ interface MenuButtonProps {
   onToggle: () => void;
 }
 
-export const MenuButton = ({isOpen, onToggle}: MenuButtonProps) => {
-  const shouldReduceMotion = useReducedMotion();
-  const animateVariant = isOpen ? 'open' : 'closed';
+export const MenuButton = React.forwardRef<HTMLButtonElement, MenuButtonProps>(
+  ({ isOpen, onToggle }, ref) => {
+    const shouldReduceMotion = useReducedMotion();
+    const animateVariant = isOpen ? "open" : "closed";
 
-  return (
-    <button
-      aria-label={`${isOpen ? "Close" : "Open"} menu`}
-      type="button"
-      onClick={onToggle}
-      className={styles['menu-button']}
-    >
-      <motion.svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="21"
-        viewBox="0 0 24 21"
-        fill="none"
-        initial={false}
-        animate={animateVariant}
-        variants={svgVariants}
-        role="presentation"
-        className={styles['svg']}
+    return (
+      <button
+        aria-expanded={isOpen}
+        aria-label={`${isOpen ? "Close" : "Open"} menu`}
+        type="button"
+        onClick={onToggle}
+        className={styles["menu-button"]}
+        ref={ref}
       >
-        <Rect
-          className="top"
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="21"
+          viewBox="0 0 24 21"
+          fill="none"
           initial={false}
           animate={animateVariant}
-          variants={topRectVariants}
-          style={{ originX: '12px', originY: '1.5px' }}
-        />
-        <Rect
-          className="middle"
-          y="9"
-          custom={shouldReduceMotion}
-          initial={false}
-          animate={animateVariant}
-          variants={middleRectVariants}
-        />
-        <Rect
-          className="bottom"
-          y="18"
-          initial={false}
-          animate={animateVariant}
-          variants={bottomRectVariants}
-          style={{ originX: '12px', originY: '19.5px' }}
-        />
-      </motion.svg>               
-    </button>
-  );
-};
+          variants={svgVariants}
+          role="presentation"
+          className={styles["svg"]}
+        >
+          <Rect
+            className="top"
+            initial={false}
+            animate={animateVariant}
+            variants={topRectVariants}
+            style={{ originX: "12px", originY: "1.5px" }}
+          />
+          <Rect
+            className="middle"
+            y="9"
+            custom={shouldReduceMotion}
+            initial={false}
+            animate={animateVariant}
+            variants={middleRectVariants}
+          />
+          <Rect
+            className="bottom"
+            y="18"
+            initial={false}
+            animate={animateVariant}
+            variants={bottomRectVariants}
+            style={{ originX: "12px", originY: "19.5px" }}
+          />
+        </motion.svg>
+      </button>
+    );
+  }
+);

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -38,7 +38,19 @@ export const MenuMobile = ({ isOpen, onToggle }: MenuMobileProps) => {
     document.body.style.overflow = "revert";
   }
 
-  // TODO: Close the menu when the user press the Escape key - Issue #48
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isOpen && event.key === "Escape") {
+        onToggle();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isOpen, onToggle]);
 
   // Preferred way compared to onAnimationComplete since it ensures the focus is set during the animation
   useEffect(() => {

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -29,14 +29,18 @@ export const MenuMobile = ({ isOpen, onToggle }: MenuMobileProps) => {
     (HTMLAnchorElement | HTMLButtonElement | null)[]
   >([]);
 
-  if (isOpen) {
-    document.body.style.overflow = "hidden";
-  }
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+      document.documentElement.style.overflow = "hidden";
+    }
 
-  if (!isOpen) {
-    activeElement?.focus();
-    document.body.style.overflow = "revert";
-  }
+    return () => {
+      activeElement?.focus();
+      document.body.style.overflow = "revert";
+      document.documentElement.style.overflow = "revert";
+    };
+  }, [isOpen, activeElement]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -8,25 +8,53 @@ import {
 import { motion } from "framer-motion";
 import { menuVariants, optionsVariants } from "./animations/menu.variants";
 import styles from "./styles/menu.module.scss";
+import { MenuButton } from "./MenuButton";
 
 const PAGES = ["Home", "Destination", "Crew", "Technology"];
 
 interface MenuMobileProps {
   isOpen: boolean;
+  onToggle: () => void;
 }
 
-/**
- * TODO: Increase menu options clickable area to enhance usability - Issue #48
- * - Update hover query by including pointer fine
- */
+// TODO: Continue with the implementation following https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 // TODO: Reduce dependency between MenuMobile and Menu
 
-export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
+export const MenuMobile = ({ isOpen, onToggle }: MenuMobileProps) => {
   const [activeMenuOptionIndex, setActiveMenuOptionIndex] = useState(-1);
   const olRef = useRef<HTMLOListElement>(null);
   const barRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const location = useLocation();
+  const activeElement = document.activeElement as HTMLElement | null;
+  const interactiveElementsRef = useRef<
+    (HTMLAnchorElement | HTMLButtonElement | null)[]
+  >([]);
+
+  if (isOpen) {
+    document.body.style.overflow = "hidden";
+  }
+
+  if (!isOpen) {
+    activeElement?.focus();
+    document.body.style.overflow = "revert";
+  }
+
+  // Preferred way compared to onAnimationComplete since it ensures the focus is set during the animation
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    if (isOpen) {
+      timeoutId = setTimeout(() => {
+        interactiveElementsRef.current[0]?.focus();
+      }, 100);
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [isOpen]);
 
   useEffect(() => {
     const newIndex = PAGES.map((item) => item.toLowerCase()).indexOf(
@@ -38,23 +66,99 @@ export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
     }
   }, [location.pathname, setActiveMenuOptionIndex]);
 
+  // TODO: Refactor this code to use a more declarative approach and commit changes
+  useEffect(() => {
+    let focusCloseButton = true;
+    let focusFirstLink = false;
+
+    if (!interactiveElementsRef.current.includes(buttonRef.current)) {
+      interactiveElementsRef.current.push(buttonRef.current);
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen) {
+        return;
+      }
+
+      if (document.activeElement === interactiveElementsRef.current[0]) {
+        focusCloseButton = true;
+      }
+
+      if (
+        document.activeElement ===
+        interactiveElementsRef.current[
+          interactiveElementsRef.current.length - 1
+        ]
+      ) {
+        focusFirstLink = true;
+      }
+
+      if (event.key === "Tab") {
+        if (event.shiftKey) {
+          focusFirstLink = false;
+          if (focusCloseButton) {
+            event.preventDefault();
+            buttonRef.current?.focus();
+            focusCloseButton = false;
+          } else if (
+            document.activeElement === interactiveElementsRef.current[1]
+          ) {
+            focusCloseButton = true;
+          }
+        } else {
+          focusCloseButton = false;
+          if (focusFirstLink) {
+            event.preventDefault();
+            interactiveElementsRef.current[0]?.focus();
+            focusFirstLink = false;
+          } else if (
+            document.activeElement ===
+            interactiveElementsRef.current[
+              interactiveElementsRef.current.length - 2
+            ]
+          ) {
+            focusFirstLink = true;
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isOpen]);
+
   const onLinkClick = (index: number) => {
     // TODO: Investigate if closing the Menu here enhances UX - Issue #48
     setActiveMenuOptionIndex(index);
   };
 
   return (
-    <motion.nav
-      initial={false}
-      animate={getMobileAnimation(isOpen)}
-      variants={optionsVariants}
+    <nav
       className={styles["menu"]}
+      role="navigation"
+      aria-label="Main Navigation"
     >
-      <ol ref={olRef}>
+      {isOpen && (
+        <div
+          className={styles.backdrop}
+          onClick={onToggle}
+          aria-hidden="true"
+        />
+      )}
+      <motion.ol
+        ref={olRef}
+        initial={false}
+        animate={getMobileAnimation(isOpen)}
+        variants={optionsVariants}
+      >
         {PAGES.map((page, index) => (
           <li key={page}>
             <NavLink
               to={`/${page}`}
+              ref={(el) => (interactiveElementsRef.current[index] = el)}
               className={getActiveClass}
               onClick={() => onLinkClick(index)}
             >
@@ -63,7 +167,8 @@ export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
             </NavLink>
           </li>
         ))}
-      </ol>
+      </motion.ol>
+      {/* TODO: Fix bar as it is being shown always and overlapped when the menu opens - Issue #48 */}
       {activeMenuOptionIndex >= 0 && (
         <motion.div
           ref={barRef}
@@ -77,6 +182,7 @@ export const MenuMobile = ({ isOpen }: MenuMobileProps) => {
           variants={menuVariants}
         />
       )}
-    </motion.nav>
+      <MenuButton ref={buttonRef} isOpen={isOpen} onToggle={onToggle} />
+    </nav>
   );
 };

--- a/src/components/NavigationBar/MenuMobile.tsx
+++ b/src/components/NavigationBar/MenuMobile.tsx
@@ -142,8 +142,8 @@ export const MenuMobile = ({ isOpen, onToggle }: MenuMobileProps) => {
   }, [isOpen]);
 
   const onLinkClick = (index: number) => {
-    // TODO: Investigate if closing the Menu here enhances UX - Issue #48
     setActiveMenuOptionIndex(index);
+    onToggle();
   };
 
   return (

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { MenuButton } from "./MenuButton";
 import { Menu } from "./Menu";
 import { useScreenType } from "../../hooks/useScreenType";
 import { MenuMobile } from "./MenuMobile";
@@ -19,9 +18,11 @@ export const NavigationBar = () => {
 
   return (
     <div className={styles["nav-container"]}>
-      {screenType === "mobile" ? <MenuMobile isOpen={isOpen} /> : <Menu />}
-      {/* TODO: Increase button clickable area to enhance usability - Issue #48 */}
-      <MenuButton isOpen={isOpen} onToggle={onToggle} />
+      {screenType === "mobile" ? (
+        <MenuMobile isOpen={isOpen} onToggle={onToggle} />
+      ) : (
+        <Menu />
+      )}
     </div>
   );
 };

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -16,7 +16,6 @@ export const NavigationBar = () => {
     setIsOpen(!isOpen);
   };
 
-  // TODO: Fix menu mobile being combined with larger screen menu - Issue #48
   return (
     <div className={styles["nav-container"]}>
       {screenType === "mobile" ? (

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -16,6 +16,7 @@ export const NavigationBar = () => {
     setIsOpen(!isOpen);
   };
 
+  // TODO: Fix menu mobile being combined with larger screen menu - Issue #48
   return (
     <div className={styles["nav-container"]}>
       {screenType === "mobile" ? (

--- a/src/components/NavigationBar/animations/menu.variants.ts
+++ b/src/components/NavigationBar/animations/menu.variants.ts
@@ -12,14 +12,14 @@ interface MenuHorizontalVariantProps extends WithOptionsProps {
   screenType: ScreenType;
 }
 
-// TODO: Check if it could be a better approach to move functions to another file
+// TODO: Check if it could be a better approach to move functions to another file - Issue #50
 const sumOptionsWidth = ({ options, index }: WithOptionsProps) => {
   return options
     .slice(0, index)
     .reduce((acc, option) => acc + option.offsetWidth, 0);
 };
 
-// TODO: Create constant values for numbers without a clear explanation
+// TODO: Create constant values for numbers without a clear explanation - Issue #50
 const calculateHorizontalMoveByViewport = ({
   screenType,
   options,
@@ -38,12 +38,11 @@ const menuVariants = {
   }),
 };
 
-// TODO: Get more knowledge on the declaration added in the transition object
+// TODO: Get more knowledge on the declaration added in the transition object - Issue #109
 const optionsVariants = {
   open: {
     opacity: 1,
     x: 0,
-    display: "flex",
     transition: {
       type: "spring",
       stiffness: 50,
@@ -53,7 +52,6 @@ const optionsVariants = {
   closed: {
     opacity: 0,
     x: "100%",
-    display: "none",
     transition: {
       delay: 0.1,
       type: "spring",

--- a/src/components/NavigationBar/animations/menu.variants.ts
+++ b/src/components/NavigationBar/animations/menu.variants.ts
@@ -1,61 +1,66 @@
-import { ScreenType } from '../../../hooks/useScreenType';
+import { ScreenType } from "../../../hooks/useScreenType";
 
 interface MenuVerticalVariantProps {
-  index: number,
+  index: number;
 }
 
 interface WithOptionsProps extends MenuVerticalVariantProps {
-  options: HTMLLIElement[],
+  options: HTMLLIElement[];
 }
 
 interface MenuHorizontalVariantProps extends WithOptionsProps {
-  screenType: ScreenType,
+  screenType: ScreenType;
 }
 
 // TODO: Check if it could be a better approach to move functions to another file
-const sumOptionsWidth = ({options, index}: WithOptionsProps) => {    
-  return options.slice(0, index).reduce((acc, option) => acc + option.offsetWidth, 0);
+const sumOptionsWidth = ({ options, index }: WithOptionsProps) => {
+  return options
+    .slice(0, index)
+    .reduce((acc, option) => acc + option.offsetWidth, 0);
 };
 
 // TODO: Create constant values for numbers without a clear explanation
-const calculateHorizontalMoveByViewport = ({screenType, options, index}: MenuHorizontalVariantProps) => {
-  const optionsGap = screenType === 'tablet' ? 38 : 48;
-  return sumOptionsWidth({options, index}) + index * optionsGap;
+const calculateHorizontalMoveByViewport = ({
+  screenType,
+  options,
+  index,
+}: MenuHorizontalVariantProps) => {
+  const optionsGap = screenType === "tablet" ? 38 : 48;
+  return sumOptionsWidth({ options, index }) + index * optionsGap;
 };
 
 const menuVariants = {
-  vertical: ({index}: MenuVerticalVariantProps) => ({
-    y: 118 + index * 51
+  vertical: ({ index }: MenuVerticalVariantProps) => ({
+    y: 118 + index * 51,
   }),
-  horizontal: ({screenType, options, index}: MenuHorizontalVariantProps) => ({
-    x: calculateHorizontalMoveByViewport({screenType, options, index})
+  horizontal: ({ screenType, options, index }: MenuHorizontalVariantProps) => ({
+    x: calculateHorizontalMoveByViewport({ screenType, options, index }),
   }),
-}
+};
 
 // TODO: Get more knowledge on the declaration added in the transition object
 const optionsVariants = {
-  open: { 
-    opacity: 1, 
-    x: 0, 
+  open: {
+    opacity: 1,
+    x: 0,
+    display: "flex",
     transition: {
       type: "spring",
       stiffness: 50,
-      restDelta: 2
-    }
+      restDelta: 2,
+    },
   },
-  closed: { 
-    opacity: 0, 
+  closed: {
+    opacity: 0,
     x: "100%",
+    display: "none",
     transition: {
       delay: 0.1,
       type: "spring",
       stiffness: 400,
-      damping: 40
-    }
+      damping: 40,
+    },
   },
 };
 
-export {
-  menuVariants,
-  optionsVariants
-};
+export { menuVariants, optionsVariants };

--- a/src/components/NavigationBar/styles/menu-button.module.scss
+++ b/src/components/NavigationBar/styles/menu-button.module.scss
@@ -7,6 +7,12 @@ $svg-size: 24px;
   padding: 0;
   position: relative;
 
+  &[aria-expanded="true"] {
+    position: fixed;
+    padding-top: 32px;
+    padding-right: 24px;
+  }
+
   // Ensure the button has a larger clickable area
   &::before {
     content: "";

--- a/src/components/NavigationBar/styles/menu-button.module.scss
+++ b/src/components/NavigationBar/styles/menu-button.module.scss
@@ -1,10 +1,20 @@
+$svg-size: 24px;
+
 .menu-button {
   cursor: pointer;
   background: none;
   border: none;
   padding: 0;
+  position: relative;
+
+  // Ensure the button has a larger clickable area
+  &::before {
+    content: "";
+    position: absolute;
+    inset: calc($svg-size / 2 * -1);
+  }
 }
 
 .svg {
-  height: 24px;
+  height: $svg-size;
 }

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -40,7 +40,7 @@
     @include bar-mixin;
   }
 
-  &:focus::before {
+  &:focus-visible::before {
     @include bar-transitions;
   }
 

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -49,6 +49,10 @@
       @include bar-transitions;
     }
   }
+
+  &[aria-current="page"]::before {
+    content: none;
+  }
 }
 
 .menu {
@@ -104,13 +108,20 @@
   background-color: transparent;
 }
 
+.bar-wrapper {
+  position: fixed;
+  right: 0;
+  top: -0.375rem;
+  width: 15.875rem; // Same width as the menu
+  z-index: 1;
+}
+
 .bar {
   position: absolute;
+  right: 0;
   width: 0.25rem;
   height: 2rem;
   background-color: v.$white;
-  right: 0;
-  top: -0.375rem;
 }
 
 // TODO: Move mobile styles to a file dedicated to `MenuMobile` and adjust the other styles here - Issue #50

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -127,15 +127,14 @@
 // TODO: Move mobile styles to a file dedicated to `MenuMobile` and adjust the other styles here - Issue #50
 @media screen and (min-width: v.$tablet) {
   .menu {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: auto;
-    height: 6rem;
-    position: revert;
-
     & ol {
+      display: flex;
       flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      width: auto;
+      height: 6rem;
+      position: revert;
       gap: 2.375rem;
       padding: 0 3rem;
 

--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -1,8 +1,8 @@
-@use 'src/styles/variables' as v;
-@use 'src/styles/fonts' as fonts;
+@use "src/styles/variables" as v;
+@use "src/styles/fonts" as fonts;
 
 @mixin bar-mixin {
-  content: '';
+  content: "";
   width: 0.25rem;
   height: 0;
   position: absolute;
@@ -41,26 +41,17 @@
   }
 
   &:focus::before {
-    @include bar-transitions
+    @include bar-transitions;
   }
 
-  @media (hover: hover) {
+  @media (hover: hover) and (pointer: fine) {
     &:hover::before {
-      @include bar-transitions
+      @include bar-transitions;
     }
   }
 }
 
 .menu {
-  width: 15.875rem;
-  height: 100vh;
-  height: 100dvh;
-  position: fixed;
-  inset: 0 0 0 auto;
-  background-color: rgba(255, 255, 255, 0.04);
-  backdrop-filter: blur(40.77px);
-  z-index: 1;
-
   & ol {
     display: flex;
     flex-direction: column;
@@ -69,6 +60,13 @@
     padding-left: 2rem;
     counter-reset: item -1;
     list-style: none;
+    width: 15.875rem;
+    height: 100dvh;
+    position: fixed;
+    inset: 0 0 0 auto;
+    background-color: rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(40.77px);
+    z-index: 1;
 
     & li {
       @include fonts.barlow-condensed;
@@ -83,6 +81,12 @@
         color: v.$white;
         text-decoration: none;
         @include pseudo-bar;
+
+        &::after {
+          content: "";
+          position: absolute;
+          inset: 0;
+        }
       }
 
       .counter {
@@ -92,6 +96,12 @@
       }
     }
   }
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: transparent;
 }
 
 .bar {

--- a/src/components/NavigationBar/styles/navigation-bar.module.scss
+++ b/src/components/NavigationBar/styles/navigation-bar.module.scss
@@ -1,4 +1,4 @@
-@use 'src/styles/variables' as v;
+@use "src/styles/variables" as v;
 
 .nav-container {
   position: relative;
@@ -9,7 +9,7 @@
     position: absolute;
     inset: 0 0 0 auto;
     height: fit-content;
-    z-index: 1;
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
### Description
This pull request introduces various changes aimed at improving the usability and accessibility of the MenuMobile component.

**Project**: [Issue #108](https://github.com/juanpb96/FEM_space-tourism-website/issues/108)

### Changes
- Accessibility
  - Include aria attributes
  - Increase the clickable area in interactable elements
  - Receive ref as a prop to update attributes accordingly 
  - Apply focus when necessary
  - Add a focus trap to keep the user looping through the menu options until one of them is clicked
  - Allow the user to close the Menu when pressing the "Escape" key
  - Add a transparent backdrop that, when clicked, will let the user close the menu
  - Remove overflows to prevent the user from perceiving odd behaviors when scrolling with the menu open or when the user has established a large font size in the device settings
  - Set a fixed position for the close button when the menu is open
- Structure
  - Move MenuButton into MenuMobile  
  - Implement the AnimationPresence component from Framer to animate more easily the enter and exit transitions in the Menu
  - Rearrange styles to prevent collisions on larger screens
- Include TODOs and IDs related to issues already created