### PR TITLE
refactor(111): Adjust Navigation Link height

### DIFF
--- a/src/components/NavigationBar/styles/menu.module.scss
+++ b/src/components/NavigationBar/styles/menu.module.scss
@@ -1,6 +1,8 @@
 @use "src/styles/variables" as v;
 @use "src/styles/fonts" as fonts;
 
+$landscape-bar-height: 0.1875rem;
+
 @mixin bar-mixin {
   content: "";
   width: 0.25rem;
@@ -16,9 +18,9 @@
 
   @media screen and (min-width: v.$tablet) {
     width: 100%;
-    height: 0.1875rem;
+    height: $landscape-bar-height;
     top: initial;
-    bottom: -2.5625rem;
+    bottom: -$landscape-bar-height;
     opacity: 0;
     transition: opacity 0.3s ease-in-out, bottom 0.3s ease-in-out;
   }
@@ -29,9 +31,9 @@
   transform: scaleY(1);
 
   @media screen and (min-width: v.$tablet) {
-    height: 0.1875rem;
+    height: $landscape-bar-height;
     opacity: v.$opacity-1;
-    bottom: -2.375rem;
+    bottom: 0;
   }
 }
 
@@ -131,7 +133,7 @@
       display: flex;
       flex-direction: row;
       justify-content: center;
-      align-items: center;
+      align-items: stretch;
       width: auto;
       height: 6rem;
       position: revert;
@@ -141,6 +143,12 @@
       & li {
         font-size: v.$fs-secondary-nav-text;
         letter-spacing: 0.14763rem;
+
+        a {
+          display: flex;
+          align-items: center;
+          height: 100%;
+        }
 
         .counter {
           display: none;


### PR DESCRIPTION
### Description
This pull request introduces some changes to adjust the navigation link height to occupy its parent's total height. 

**Project**: [Issue #111](https://github.com/juanpb96/FEM_space-tourism-website/issues/111)

### Changes
- Increase navigation link height to 100%
- Adjust bar styles accordingly to reflect the focus state in the navigation link

### Evidence
<img width="748" height="246" alt="Navigation link focused on tablet" src="https://github.com/user-attachments/assets/87854b56-e1fd-4aa3-a714-a30ceebef491" />

